### PR TITLE
Fixes #8. feat: byte-aware filename truncation and --max-filename-bytes flag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ __marimo__/
 .streamlit/secrets.toml
 
 diff.txt
+
+# WSL integration test artifacts
+test_files/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [//]: # (- **Security** in case of vulnerabilities.)
 
+## [1.5.0] - 2026-02-19
+
+### Added
+
+- `--max-filename-bytes N` flag to set a custom maximum filename length in bytes (valid range: 4–255, default: 255)
+- Test suite for filename sanitization (`tests/test_sanitize.py`)
+
+### Changed
+
+- Filename truncation is now **byte-aware** instead of character-based ([#8](https://github.com/Jemeni11/CrossRename/issues/8))
+  - ext4/btrfs filesystems limit filenames to 255 **bytes**, not 255 characters
+  - Multi-byte UTF-8 characters (CJK, Cyrillic, emoji) are now correctly accounted for
+  - This is a behavioral change: filenames with non-ASCII characters that previously passed unchanged may now be truncated to fit the byte limit
+- Updated README and PyPI README to clarify the byte-based limit
+
 ## [1.4.0] - 2026-02-07
 
 ### Added
@@ -101,6 +116,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.0] - 2024-10-07
 
 - Released CrossRename
+
+[1.5.0]: https://github.com/Jemeni11/CrossRename/compare/v1.4.0...v1.5.0
 
 [1.4.0]: https://github.com/Jemeni11/CrossRename/compare/v1.3.0...v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [//]: # (- **Security** in case of vulnerabilities.)
 
-## [1.5.0] - 2026-02-19
+## [1.5.0] - 2026-02-21
 
 ### Added
 

--- a/CrossRename/main.py
+++ b/CrossRename/main.py
@@ -6,7 +6,7 @@ import argparse
 import logging
 from .utils import check_for_update
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(
@@ -29,13 +29,15 @@ def get_extension(filename: str) -> str:
     return "".join(suffixes[-2:]) if len(suffixes) > 1 else suffixes[-1]
 
 
-def sanitize_filename(filename: str, use_alternatives: bool = False) -> str:
+def sanitize_filename(filename: str, use_alternatives: bool = False, max_bytes: int = 255) -> str:
     """
     Sanitizes filename to be Windows-compatible (and thus Linux-compatible and macOS-compatible)
 
     :param filename: The original filename to sanitize
     :param use_alternatives: If True, replace forbidden characters with Unicode lookalikes
                  instead of removing them. May cause display/compatibility issues.
+    :param max_bytes: Maximum filename length in bytes (default: 255 for ext4/btrfs compatibility).
+                 Multi-byte UTF-8 characters (CJK, emoji, etc.) consume more of this budget.
     :return: The sanitized filename
     """
     # A file name can't contain any of the following characters on Windows: \ / : * ? " < > |
@@ -80,22 +82,26 @@ def sanitize_filename(filename: str, use_alternatives: bool = False) -> str:
     if filename.startswith(".") and not sanitized.startswith("."):
         sanitized = "." + sanitized
 
-    # Truncate filename if it's too long (255-character limit for name+extension)
-    max_length = 255
-    if len(sanitized) > max_length:
+    # Truncate filename if it exceeds the byte limit (default 255 for ext4/btrfs).
+    # We measure bytes because ext4/btrfs limit filenames to 255 bytes, not characters.
+    # Multi-byte UTF-8 chars (CJK, emoji, etc.) consume more of this budget.
+    if len(sanitized.encode("utf-8")) > max_bytes:
         ext = get_extension(sanitized)
-        ext_length = len(ext)
-        name = sanitized[:-ext_length] if ext else sanitized
-        sanitized = name[: max_length - ext_length] + ext
+        ext_bytes = len(ext.encode("utf-8"))
+        name = sanitized[: -len(ext)] if ext else sanitized
+        # Remove characters from the end until the total fits within the byte limit
+        while len(name.encode("utf-8")) + ext_bytes > max_bytes and name:
+            name = name[:-1]
+        sanitized = name + ext
 
     return sanitized
 
 
 def rename_file(
-    file_path: str, dry_run: bool = False, use_alternatives: bool = False
+    file_path: str, dry_run: bool = False, use_alternatives: bool = False, max_bytes: int = 255
 ) -> None:
     directory, filename = os.path.split(file_path)
-    new_filename = sanitize_filename(filename, use_alternatives)
+    new_filename = sanitize_filename(filename, use_alternatives, max_bytes)
 
     if new_filename != filename:
         new_file_path = os.path.join(directory, new_filename)
@@ -175,11 +181,11 @@ def collect_directories(directory: str) -> list[str]:
 
 
 def rename_directory(
-    dir_path: str, dry_run: bool = False, use_alternatives: bool = False
+    dir_path: str, dry_run: bool = False, use_alternatives: bool = False, max_bytes: int = 255
 ) -> str:
     """Rename directory and return the new path"""
     parent_dir, dir_name = os.path.split(dir_path)
-    new_dir_name = sanitize_filename(dir_name, use_alternatives)
+    new_dir_name = sanitize_filename(dir_name, use_alternatives, max_bytes)
 
     if new_dir_name != dir_name:
         new_dir_path = os.path.join(parent_dir, new_dir_name)
@@ -326,6 +332,16 @@ def main() -> None:
             help="Show credits and support information",
             action="store_true",
         )
+        parser.add_argument(
+            "--max-filename-bytes",
+            type=int,
+            default=255,
+            metavar="N",
+            help="Maximum filename length in bytes (default: 255, valid range: 4-255). "
+                 "Filenames exceeding this limit will be truncated. The default of 255 bytes "
+                 "ensures compatibility with Linux filesystems (ext4, btrfs). "
+                 "Multi-byte characters (CJK, Cyrillic, emoji) consume more bytes per character.",
+        )
 
         args = parser.parse_args()
         path = args.path
@@ -333,6 +349,10 @@ def main() -> None:
         dry_run = args.dry_run
         rename_dirs = args.rename_directories
         use_alternatives = args.use_alternatives
+        max_bytes = args.max_filename_bytes
+
+        if not (4 <= max_bytes <= 255):
+            sys.exit("Error: --max-filename-bytes must be between 4 and 255.")
 
         if args.update:
             check_for_update(__version__)
@@ -356,28 +376,28 @@ def main() -> None:
             )
 
         if os.path.isfile(path):
-            rename_file(path, dry_run, use_alternatives)
+            rename_file(path, dry_run, use_alternatives, max_bytes)
         elif os.path.isdir(path):
             if recursive:
                 # First rename directories (deepest first)
                 if rename_dirs:
                     directories = collect_directories(path)
                     for dir_path in directories:
-                        rename_directory(dir_path, dry_run, use_alternatives)
+                        rename_directory(dir_path, dry_run, use_alternatives, max_bytes)
 
                 # Then rename files (using updated paths)
                 file_list = file_search(path)
                 for file_path in file_list:
-                    rename_file(file_path, dry_run, use_alternatives)
+                    rename_file(file_path, dry_run, use_alternatives, max_bytes)
             else:
                 if rename_dirs:
-                    path = rename_directory(path, dry_run, use_alternatives)
+                    path = rename_directory(path, dry_run, use_alternatives, max_bytes)
 
                 # Handle files in the directory
                 for item in os.listdir(path):
                     item_path = os.path.join(path, item)
                     if os.path.isfile(item_path):
-                        rename_file(item_path, dry_run, use_alternatives)
+                        rename_file(item_path, dry_run, use_alternatives, max_bytes)
         else:
             sys.exit(f"Error: {path} is not a valid file or directory")
     except Exception as e:

--- a/PYPI_README.rst
+++ b/PYPI_README.rst
@@ -43,6 +43,7 @@ Features
 --------
 
 - Sanitizes file names to be Windows-compatible (and thus Linux-compatible and macOS-compatible)
+- Byte-aware filename truncation (correctly handles CJK, Cyrillic, emoji, and other multi-byte UTF-8 characters)
 - Option to replace forbidden characters with Unicode lookalikes instead of removing them
 - Optionally renames directories to be cross-platform compatible
 - Handles both individual files and entire directories
@@ -148,6 +149,12 @@ Show credits and project information:
 
    crossrename --credits
 
+Limit filename length for Linux filesystems (useful for CJK or emoji-heavy filenames):
+
+.. code-block:: bash
+
+   crossrename -p /path/to/directory -r --max-filename-bytes 255
+
 `back to introduction  <introduction_>`__
 
 
@@ -222,8 +229,35 @@ ensuring files work everywhere. This means:
 - Removing Windows-forbidden characters: ``< > : " / \ | ? *``
 - Handling Windows reserved names: CON, PRN, AUX, NUL, COM1-9, LPT1-9
 - Removing trailing spaces and periods
-- Limiting filenames to 255 bytes (for ext4/btrfs compatibility; configurable via ``--max-filename-bytes``)
 - Removing control characters
+- Limiting filenames to 255 **bytes** (for ext4/btrfs compatibility; configurable via ``--max-filename-bytes``)
+
+.. note::
+   **Prior to v1.5.0**, CrossRename limited filenames to 255 **characters**, which could still produce
+   filenames that fail on Linux. ext4 and btrfs enforce a 255 **byte** limit, not a character limit.
+   Since non-ASCII characters in UTF-8 occupy more than one byte, the effective character limit is lower:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Script
+        - Bytes per char
+        - Effective limit
+      * - Latin (ASCII)
+        - 1
+        - ~255 characters
+      * - Cyrillic
+        - 2
+        - ~127 characters
+      * - CJK (Chinese, Japanese, Korean)
+        - 3
+        - ~85 characters
+      * - Emoji
+        - 4
+        - ~63 characters
+
+   v1.5.0 fixes this with byte-aware truncation. If you have files that were previously
+   "within the limit" but still fail to copy to a Linux filesystem, re-run CrossRename to truncate them correctly.
 
 Since Windows has the strictest rules, files renamed by CrossRename will work on Linux and macOS without issues.
 

--- a/PYPI_README.rst
+++ b/PYPI_README.rst
@@ -72,7 +72,7 @@ Usage
 
 .. code-block:: text
 
-   usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--credits]
+   usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--max-filename-bytes N] [--credits]
 
    CrossRename: Harmonize file and directory names for Linux, Windows and macOS.
 
@@ -86,6 +86,7 @@ Usage
      -D, --rename-directories    Also rename directories to be cross-platform compatible. Use with caution!
      -a, --use-alternatives      Replace forbidden characters with Unicode lookalikes instead of removing them. May cause display issues on some systems.
      --force                     Skip safety prompts (useful for automated scripts)
+     --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 4-255).
      --credits                   Show credits and support information
 
 `back to introduction  <introduction_>`__
@@ -221,7 +222,7 @@ ensuring files work everywhere. This means:
 - Removing Windows-forbidden characters: ``< > : " / \ | ? *``
 - Handling Windows reserved names: CON, PRN, AUX, NUL, COM1-9, LPT1-9
 - Removing trailing spaces and periods
-- Limiting filenames to 255 characters
+- Limiting filenames to 255 bytes (for ext4/btrfs compatibility; configurable via ``--max-filename-bytes``)
 - Removing control characters
 
 Since Windows has the strictest rules, files renamed by CrossRename will work on Linux and macOS without issues.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Other package managers coming soon.
 ## Usage
 
 ```bash
-usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--credits]
+usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--max-filename-bytes N] [--credits]
 
 CrossRename: Harmonize file and directory names for Linux, Windows and macOS.
 
@@ -83,6 +83,7 @@ options:
   -D, --rename-directories    Also rename directories to be cross-platform compatible. Use with caution!
   -a, --use-alternatives      Replace forbidden characters with Unicode lookalikes instead of removing them. May cause display issues on some systems.
   --force                     Skip safety prompts (useful for automated scripts)
+  --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 4-255).
   --credits                   Show credits and support information
 ```
 
@@ -215,7 +216,7 @@ ensuring files work everywhere. This means:
 - Removing Windows-forbidden characters: `< > : " / \ | ? *`
 - Handling Windows reserved names: CON, PRN, AUX, NUL, COM1-9, LPT1-9
 - Removing trailing spaces and periods
-- Limiting filenames to 255 characters
+- Limiting filenames to 255 bytes (for ext4/btrfs compatibility; configurable via `--max-filename-bytes`)
 - Removing control characters
 
 Since Windows has the strictest rules, files renamed by CrossRename will work on Linux and macOS without issues.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ when transferring files between different environments.
 ## Features
 
 - Sanitizes file names to be Windows-compatible (and thus Linux-compatible and macOS-compatible)
+- Byte-aware filename truncation (correctly handles CJK, Cyrillic, emoji, and other multi-byte UTF-8 characters)
 - Option to replace forbidden characters with Unicode lookalikes instead of removing them
 - Optionally renames directories to be cross-platform compatible
 - Handles both individual files and entire directories
@@ -145,6 +146,12 @@ Show credits and project information:
 crossrename --credits
 ```
 
+Limit filename length for Linux filesystems (useful for CJK or emoji-heavy filenames):
+
+```bash
+crossrename -p /path/to/directory -r --max-filename-bytes 255
+```
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Unicode Alternatives Mode
@@ -216,8 +223,23 @@ ensuring files work everywhere. This means:
 - Removing Windows-forbidden characters: `< > : " / \ | ? *`
 - Handling Windows reserved names: CON, PRN, AUX, NUL, COM1-9, LPT1-9
 - Removing trailing spaces and periods
-- Limiting filenames to 255 bytes (for ext4/btrfs compatibility; configurable via `--max-filename-bytes`)
 - Removing control characters
+- Limiting filenames to 255 **bytes** (for ext4/btrfs compatibility; configurable via `--max-filename-bytes`)
+
+> [!NOTE]
+> **Prior to v1.5.0**, CrossRename limited filenames to 255 **characters**, which could still produce
+> filenames that fail on Linux. ext4 and btrfs enforce a 255 **byte** limit, not a character limit.
+> Since non-ASCII characters in UTF-8 occupy more than one byte, the effective character limit is lower:
+>
+> | Script | Bytes per char | Effective limit |
+> | ------ | -------------- | --------------- |
+> | Latin (ASCII) | 1 | ~255 characters |
+> | Cyrillic | 2 | ~127 characters |
+> | CJK (Chinese, Japanese, Korean) | 3 | ~85 characters |
+> | Emoji | 4 | ~63 characters |
+>
+> v1.5.0 fixes this with byte-aware truncation. If you have files that were previously
+> "within the limit" but still fail to copy to a Linux filesystem, re-run CrossRename to truncate them correctly.
 
 Since Windows has the strictest rules, files renamed by CrossRename will work on Linux and macOS without issues.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "CrossRename"
-version = "1.4.0"
+version = "1.5.0"
 authors = [
     { name = "Emmanuel C. Jemeni", email = "jemenichinonso11@gmail.com" }
 ]

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,135 @@
+from CrossRename.main import sanitize_filename, get_extension
+
+
+class TestGetExtension:
+    def test_simple_extension(self):
+        assert get_extension("file.txt") == ".txt"
+
+    def test_compound_extension(self):
+        assert get_extension("archive.tar.gz") == ".tar.gz"
+
+    def test_no_extension(self):
+        assert get_extension("README") == ""
+
+    def test_dotfile(self):
+        # Path('.gitignore').suffixes returns [] — Python treats it as a stem, not an extension
+        assert get_extension(".gitignore") == ""
+
+
+class TestSanitizeFilenameByteLimit:
+    """Tests for byte-aware filename truncation (issue #8)."""
+
+    def test_ascii_at_255_bytes_unchanged(self):
+        """255 ASCII chars = 255 bytes, should not be truncated."""
+        name = "a" * 251 + ".txt"  # 251 + 4 = 255 bytes
+        result = sanitize_filename(name)
+        assert result == name
+        assert len(result.encode("utf-8")) == 255
+
+    def test_ascii_exceeding_255_bytes_truncated(self):
+        """256+ ASCII chars should be truncated to fit 255 bytes."""
+        name = "a" * 260 + ".txt"
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        assert result.endswith(".txt")
+
+    def test_cjk_exceeding_255_bytes(self):
+        """CJK chars are 3 bytes each in UTF-8. 100 CJK chars = 300 bytes."""
+        name = "中" * 100  # 300 bytes
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        # Should be ~85 characters (85 * 3 = 255)
+        assert len(result) == 85
+
+    def test_cjk_with_extension(self):
+        """CJK filename with extension: extension must be preserved."""
+        name = "中" * 100 + ".txt"  # 300 + 4 = 304 bytes
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        assert result.endswith(".txt")
+
+    def test_emoji_exceeding_255_bytes(self):
+        """Emoji are 4 bytes each in UTF-8. 70 emoji = 280 bytes."""
+        name = "😀" * 70
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        # Should be ~63 characters (63 * 4 = 252)
+        assert len(result) == 63
+
+    def test_cyrillic_exceeding_255_bytes(self):
+        """Cyrillic chars are 2 bytes each. 200 Cyrillic chars = 400 bytes."""
+        name = "щ" * 200
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        # Should be ~127 characters (127 * 2 = 254)
+        assert len(result) == 127
+
+    def test_mixed_ascii_and_multibyte(self):
+        """Mixed ASCII + CJK should be byte-counted correctly."""
+        # 100 ASCII (100 bytes) + 60 CJK (180 bytes) = 280 bytes
+        name = "a" * 100 + "中" * 60
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+
+    def test_exactly_255_bytes_unchanged(self):
+        """A filename at exactly 255 bytes should not be modified."""
+        name = "中" * 85  # 85 * 3 = 255 bytes
+        result = sanitize_filename(name)
+        assert result == name
+        assert len(result.encode("utf-8")) == 255
+
+    def test_compound_extension_preserved(self):
+        """Compound extensions like .tar.gz should be preserved during truncation."""
+        name = "中" * 100 + ".tar.gz"  # 300 + 7 = 307 bytes
+        result = sanitize_filename(name)
+        assert len(result.encode("utf-8")) <= 255
+        assert result.endswith(".tar.gz")
+
+    def test_custom_max_bytes_lower(self):
+        """Custom max_bytes should truncate accordingly."""
+        name = "a" * 200
+        result = sanitize_filename(name, max_bytes=100)
+        assert len(result.encode("utf-8")) <= 100
+        assert len(result) == 100
+
+    def test_custom_max_bytes_with_extension(self):
+        """Custom max_bytes with extension preserved."""
+        name = "a" * 200 + ".py"
+        result = sanitize_filename(name, max_bytes=50)
+        assert len(result.encode("utf-8")) <= 50
+        assert result.endswith(".py")
+
+    def test_short_filename_unchanged(self):
+        """Short filenames should never be truncated."""
+        name = "hello.txt"
+        result = sanitize_filename(name)
+        assert result == name
+
+
+class TestSanitizeFilenameCharacters:
+    """Tests for character sanitization (existing behavior)."""
+
+    def test_removes_windows_forbidden_chars(self):
+        result = sanitize_filename('file<name>with:bad"chars.txt')
+        assert result == "filenamewithbadchars.txt"
+
+    def test_unicode_alternatives_mode(self):
+        result = sanitize_filename("file<name>.txt", use_alternatives=True)
+        assert "ᐸ" in result
+        assert "ᐳ" in result
+
+    def test_reserved_names_prefixed(self):
+        result = sanitize_filename("CON.txt")
+        assert result == "_CON.txt"
+
+    def test_trailing_spaces_and_periods_removed(self):
+        result = sanitize_filename("file.txt...")
+        assert result == "file.txt"
+
+    def test_empty_after_sanitization(self):
+        result = sanitize_filename('<<<>>>"')
+        assert result == "unnamed_file"
+
+    def test_control_characters_removed(self):
+        result = sanitize_filename("file\x01\x02name.txt")
+        assert result == "filename.txt"

--- a/tests/test_wsl.sh
+++ b/tests/test_wsl.sh
@@ -2,45 +2,35 @@
 # =============================================================================
 # CrossRename WSL Integration Test
 # =============================================================================
-# Creates files with Windows-incompatible names on a Linux filesystem,
-# runs CrossRename against them, and verifies the results.
+# Tests byte-aware truncation (Issue #8) and standard filename sanitization.
 #
-# Usage (from WSL):
-#   cd /mnt/c/Users/HP/Documents/Code/CrossRename
+# Usage (from WSL or Linux):
 #   bash tests/test_wsl.sh [--keep]
-#
-# From PowerShell:
-#   wsl bash -c "cd /mnt/c/Users/HP/Documents/Code/CrossRename && bash tests/test_wsl.sh"
 #
 # Options:
 #   --keep    Don't clean up test_files/ after running (for manual inspection)
+#
+# Requirements:
+#   - CrossRename installed (pip install crossrename  OR  pip install -e .)
+#   - Python 3
+#   - Linux/WSL (ext4 or btrfs filesystem)
 # =============================================================================
 
 set -euo pipefail
 
 # --- Colors ---
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m' # No Color
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'
+BOLD='\033[1m'; NC='\033[0m'
 
 # --- Config ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TEST_DIR="$PROJECT_DIR/test_files"
 KEEP=false
-PASS=0
-FAIL=0
+PASS=0; FAIL=0
 
 # --- Parse args ---
-for arg in "$@"; do
-    case "$arg" in
-        --keep) KEEP=true ;;
-        *) echo -e "${RED}Unknown argument: $arg${NC}"; exit 1 ;;
-    esac
-done
+for arg in "$@"; do case "$arg" in --keep) KEEP=true;; *) echo -e "${RED}Unknown argument: $arg${NC}"; exit 1;; esac; done
 
 # --- Helpers ---
 header() {
@@ -49,122 +39,90 @@ header() {
     echo -e "${CYAN}${BOLD}  $1${NC}"
     echo -e "${CYAN}${BOLD}═══════════════════════════════════════════════════${NC}"
 }
-
-section() {
-    echo ""
-    echo -e "${YELLOW}--- $1 ---${NC}"
-}
+section() { echo ""; echo -e "${YELLOW}--- $1 ---${NC}"; }
 
 check_file_exists() {
-    local file="$1"
-    local description="$2"
-    if [ -f "$TEST_DIR/$file" ]; then
-        echo -e "  ${GREEN}✓ PASS${NC}: $description → '$file' exists"
-        ((PASS++))
-    else
-        echo -e "  ${RED}✗ FAIL${NC}: $description → '$file' not found"
-        ((FAIL++))
-    fi
+    local d="$1" f="$2" desc="$3"
+    [ -f "$d/$f" ] && { echo -e "  ${GREEN}✓ PASS${NC}: $desc"; ((PASS++)); } \
+                   || { echo -e "  ${RED}✗ FAIL${NC}: $desc ('$f' missing)"; ((FAIL++)); }
 }
 
 check_file_absent() {
-    local file="$1"
-    local description="$2"
-    if [ ! -f "$TEST_DIR/$file" ]; then
-        echo -e "  ${GREEN}✓ PASS${NC}: $description → '$file' correctly removed/renamed"
-        ((PASS++))
-    else
-        echo -e "  ${RED}✗ FAIL${NC}: $description → '$file' still exists (should have been renamed)"
-        ((FAIL++))
-    fi
+    local d="$1" f="$2" desc="$3"
+    [ ! -f "$d/$f" ] && { echo -e "  ${GREEN}✓ PASS${NC}: $desc"; ((PASS++)); } \
+                      || { echo -e "  ${RED}✗ FAIL${NC}: $desc ('$f' remains)"; ((FAIL++)); }
 }
 
-# Verify that a file matching the prefix exists and its name is within the byte limit
 check_truncated() {
-    local prefix="$1"
-    local max_bytes="$2"
-    local description="$3"
-    local found=false
-    for f in "$TEST_DIR/$prefix"*; do
+    local target_dir="$1" prefix="$2" max_bytes="$3" desc="$4"
+    for f in "$target_dir/$prefix"*; do
         if [ -f "$f" ]; then
-            local basename
-            basename=$(basename "$f")
-            local byte_len
-            byte_len=$(echo -n "$basename" | wc -c)
+            local name; name="$(basename "$f")"
+            local byte_len; byte_len="$(echo -n "$name" | wc -c)"
             if [ "$byte_len" -le "$max_bytes" ]; then
-                echo -e "  ${GREEN}✓ PASS${NC}: $description → '${basename}' (${byte_len} bytes ≤ ${max_bytes})"
-                ((PASS++))
-            else
-                echo -e "  ${RED}✗ FAIL${NC}: $description → '${basename}' is ${byte_len} bytes (limit: ${max_bytes})"
-                ((FAIL++))
+                echo -e "  ${GREEN}✓ PASS${NC}: $desc (${byte_len}/${max_bytes} bytes)"
+                ((PASS++)); return
             fi
-            found=true
-            break
         fi
     done
-    if [ "$found" = false ]; then
-        echo -e "  ${RED}✗ FAIL${NC}: $description → no file matching '${prefix}*' found"
-        ((FAIL++))
-    fi
+    echo -e "  ${RED}✗ FAIL${NC}: $desc (no valid '$prefix*' file found under limit)"
+    ((FAIL++))
 }
 
 cleanup() {
-    if [ -d "$TEST_DIR" ]; then
+    if [ "$KEEP" = false ] && [ -d "$TEST_DIR" ]; then
         rm -rf "$TEST_DIR"
         echo -e "${YELLOW}Cleaned up $TEST_DIR${NC}"
     fi
 }
-
-# --- Cleanup on exit (unless --keep) ---
-if [ "$KEEP" = false ]; then
-    trap cleanup EXIT
-fi
+trap cleanup EXIT
 
 # =============================================================================
 # PHASE 1: Setup
 # =============================================================================
 header "Phase 1: Setup"
 
-# Clean any previous test run
-if [ -d "$TEST_DIR" ]; then
-    echo "Removing previous test_files/..."
-    rm -rf "$TEST_DIR"
-fi
-
+[ -d "$TEST_DIR" ] && { echo "Removing previous test_files/..."; rm -rf "$TEST_DIR"; }
 mkdir -p "$TEST_DIR"
-echo -e "Created ${BOLD}$TEST_DIR${NC}"
+echo -e "Created test dir: ${BOLD}$TEST_DIR${NC}"
 
-# Detect CrossRename command
+# --- Detect CrossRename ---
 section "Detecting CrossRename"
-cd "$PROJECT_DIR"
 CROSSRENAME=""
 USE_WINPATH=false
+
 if command -v crossrename &>/dev/null; then
     CROSSRENAME="crossrename"
 elif command -v crossrename.exe &>/dev/null; then
     CROSSRENAME="crossrename.exe"
     USE_WINPATH=true
 elif python3 -c "from CrossRename.main import main" &>/dev/null 2>&1; then
-    CROSSRENAME="python3 -m CrossRename.main"
+    CROSSRENAME="python3 -m CrossRename"
 elif python -c "from CrossRename.main import main" &>/dev/null 2>&1; then
-    CROSSRENAME="python -m CrossRename.main"
+    CROSSRENAME="python -m CrossRename"
 else
     echo -e "${RED}ERROR: CrossRename not found.${NC}"
-    echo "  Install it with: pip install -e .  (or pip install CrossRename)"
+    echo "  Install with: pip install crossrename"
+    echo "  Or for dev:   pip install -e ."
     exit 1
 fi
 
-# Convert paths for Windows executables running via WSL interop
-resolve_path() {
-    if [ "$USE_WINPATH" = true ]; then
-        wslpath -w "$1"
-    else
-        echo "$1"
-    fi
-}
+resolve_path() { [[ "$USE_WINPATH" == true ]] && wslpath -w "$1" || echo "$1"; }
 
 echo -e "Using: ${BOLD}$CROSSRENAME${NC}"
 $CROSSRENAME -v
+
+# --- Detect Python ---
+section "Detecting Python"
+PYTHON=""
+if command -v python3 &>/dev/null; then
+    PYTHON="python3"
+elif command -v python &>/dev/null; then
+    PYTHON="python"
+else
+    echo -e "${RED}ERROR: Python not found.${NC}"; exit 1
+fi
+echo -e "Using: ${BOLD}$PYTHON${NC}"
 
 # =============================================================================
 # PHASE 2: Create test files
@@ -172,180 +130,172 @@ $CROSSRENAME -v
 header "Phase 2: Creating test files"
 
 section "Forbidden Windows characters"
-touch "$TEST_DIR/file<with>brackets.txt"
-touch "$TEST_DIR/file:with:colons.txt"
-touch "$TEST_DIR/file\"with\"quotes.txt"
-touch "$TEST_DIR/file|with|pipes.txt"
-touch "$TEST_DIR/file?with?questions.txt"
-touch "$TEST_DIR/file*with*asterisks.txt"
-echo "  Created 6 files with forbidden characters"
-
-section "Trailing spaces and periods"
-touch "$TEST_DIR/trailing_space .txt"
-touch "$TEST_DIR/trailing_period..txt"
-echo "  Created 2 files with trailing spaces/periods"
+touch "$TEST_DIR/file<with>brackets.txt" \
+      "$TEST_DIR/file:with:colons.txt" \
+      "$TEST_DIR/file?with?questions.txt" \
+      "$TEST_DIR/file*with*asterisks.txt" \
+      "$TEST_DIR/file|with|pipes.txt" \
+      "$TEST_DIR/file\"with\"quotes.txt"
+echo "  Created 6 files with forbidden characters ✓"
 
 section "Reserved Windows names"
-touch "$TEST_DIR/CON.txt"
-touch "$TEST_DIR/NUL.txt"
-touch "$TEST_DIR/COM1.txt"
-touch "$TEST_DIR/LPT1.txt"
-touch "$TEST_DIR/PRN.txt"
-touch "$TEST_DIR/AUX.txt"
-echo "  Created 6 files with reserved names"
+touch "$TEST_DIR/CON.txt" "$TEST_DIR/NUL.txt" "$TEST_DIR/COM1.txt" \
+      "$TEST_DIR/LPT1.txt" "$TEST_DIR/PRN.txt" "$TEST_DIR/AUX.txt"
+echo "  Created 6 reserved name files ✓"
 
 section "Control characters"
-touch "$TEST_DIR/file$(printf '\x01')ctrl.txt"
-touch "$TEST_DIR/file$(printf '\x1f')ctrl2.txt"
-echo "  Created 2 files with control characters"
+touch "$TEST_DIR/file$(printf '\x01')ctrl.txt" \
+      "$TEST_DIR/file$(printf '\x1f')ctrl2.txt"
+echo "  Created 2 control character files ✓"
 
-section "Emoji filenames"
-touch "$TEST_DIR/🎉party🎊time.txt"
-touch "$TEST_DIR/📁folder📂icon.txt"
-touch "$TEST_DIR/日本語ファイル.txt"
-echo "  Created 3 files with emoji/CJK characters"
+section "Emoji and CJK filenames (should be unchanged)"
+touch "$TEST_DIR/🎉party🎊time.txt" \
+      "$TEST_DIR/📁folder📂icon.txt" \
+      "$TEST_DIR/日本語ファイル.txt"
+echo "  Created 3 emoji/CJK files ✓"
 
-section "Filename truncation (byte limit)"
-# 300 ASCII chars + .txt = 304 bytes (exceeds 255)
-LONG_ASCII=$(printf 'a%.0s' $(seq 1 300))
-touch "$TEST_DIR/${LONG_ASCII}.txt"
-# 100 CJK chars = 300 bytes (each is 3 bytes in UTF-8)
-LONG_CJK=$(printf '中%.0s' $(seq 1 100))
-touch "$TEST_DIR/${LONG_CJK}.txt"
-# 70 emoji = 280 bytes (each is 4 bytes in UTF-8)
-LONG_EMOJI=$(printf '😀%.0s' $(seq 1 70))
-touch "$TEST_DIR/${LONG_EMOJI}.txt"
-# Long name with compound extension
-LONG_TAR=$(printf 'b%.0s' $(seq 1 300))
-touch "$TEST_DIR/${LONG_TAR}.tar.gz"
-echo "  Created 4 files exceeding 255-byte limit"
+section "Byte truncation (Option 1: custom --max-filename-bytes)"
+# All safely under 255 bytes so they create cleanly on ext4/btrfs
+LONG_ASCII=$(printf 'a%.0s' {1..250}); touch "$TEST_DIR/${LONG_ASCII}.txt"   # 254 bytes
+LONG_CJK=$(printf '中%.0s' {1..83});   touch "$TEST_DIR/${LONG_CJK}.txt"     # 253 bytes
+LONG_EMOJI=$(printf '😀%.0s' {1..61}); touch "$TEST_DIR/${LONG_EMOJI}.txt"   # 248 bytes
+echo "  Created 3 long files (all <255 bytes, truncated by --max-filename-bytes 100) ✓"
 
-section "Combination of issues"
-touch "$TEST_DIR/bad<name>:file?.txt"
-touch "$TEST_DIR/CON:bad|name .txt"
-echo "  Created 2 files with multiple issues"
-
-section "Files that should NOT change"
-touch "$TEST_DIR/normal_file.txt"
-touch "$TEST_DIR/another-file.md"
-touch "$TEST_DIR/.hidden_file"
-echo "  Created 3 clean files (should be unchanged)"
+section "Clean files (should be unchanged)"
+touch "$TEST_DIR/normal_file.txt" \
+      "$TEST_DIR/another-file.md" \
+      "$TEST_DIR/.hidden_file"
+echo "  Created 3 clean files ✓"
 
 echo ""
 echo -e "${BOLD}Total files created: $(ls -1A "$TEST_DIR" | wc -l)${NC}"
 
 # =============================================================================
-# PHASE 3: Dry run
+# PHASE 3: Issue #8 — Extreme byte length verification (mocked)
 # =============================================================================
-header "Phase 3: Dry Run"
+header "Phase 3: Issue #8 Byte Math Verification"
+section "Testing extreme CJK/Emoji lengths via sanitize_filename()"
 
+# Note: We verify this by calling the Python function directly because
+# files exceeding 255 bytes cannot be created on any standard Linux filesystem
+# (ext4/btrfs) or via WSL's Windows drive interop (drvfs), regardless of NTFS.
+PHASE3_PASS=true
+$PYTHON -c "
+import sys
+from CrossRename.main import sanitize_filename
+
+tests = [
+    ('中' * 120 + '.txt',  255, '120 CJK chars (360 bytes) → ≤255 bytes'),
+    ('😀' * 80  + '.txt',  255, '80 Emoji (324 bytes) → ≤255 bytes'),
+    ('щ'  * 200 + '.txt',  255, '200 Cyrillic chars (404 bytes) → ≤255 bytes'),
+    ('中' * 120 + '.txt',  100, '120 CJK chars with custom limit → ≤100 bytes'),
+]
+
+failed = 0
+for original, limit, desc in tests:
+    result = sanitize_filename(original, max_bytes=limit)
+    result_bytes = len(result.encode('utf-8'))
+    if result_bytes <= limit:
+        print(f'  \u2713 PASS: {desc} (got {result_bytes} bytes)')
+    else:
+        print(f'  \u2717 FAIL: {desc} (got {result_bytes} bytes, limit {limit})')
+        failed += 1
+
+sys.exit(failed)
+" || PHASE3_PASS=false
+
+if [ "$PHASE3_PASS" = true ]; then
+    ((PASS+=4))
+else
+    ((FAIL+=1))
+fi
+
+# =============================================================================
+# PHASE 4: Dry run
+# =============================================================================
+header "Phase 4: Dry Run"
 echo -e "${YELLOW}Running: $CROSSRENAME -p $(resolve_path "$TEST_DIR") -r -d${NC}"
 echo ""
 $CROSSRENAME -p "$(resolve_path "$TEST_DIR")" -r -d
 echo ""
-echo -e "${GREEN}Dry run complete. No files were renamed.${NC}"
 
-# Verify nothing actually changed in dry run
-section "Verifying dry run didn't rename anything"
+# Verify nothing was renamed during dry run
 if [ -f "$TEST_DIR/file<with>brackets.txt" ]; then
-    echo -e "  ${GREEN}✓ PASS${NC}: Dry run did not modify files"
+    echo -e "  ${GREEN}✓ PASS${NC}: Dry run made no changes"
     ((PASS++))
 else
-    echo -e "  ${RED}✗ FAIL${NC}: Dry run modified files unexpectedly"
+    echo -e "  ${RED}✗ FAIL${NC}: Dry run unexpectedly modified files"
     ((FAIL++))
 fi
 
 # =============================================================================
-# PHASE 4: Actual rename
+# PHASE 5: Actual rename (standard 255-byte limit)
 # =============================================================================
-header "Phase 4: Actual Rename"
-
+header "Phase 5: Rename — Standard (255 bytes)"
 echo -e "${YELLOW}Running: $CROSSRENAME -p $(resolve_path "$TEST_DIR") -r --force${NC}"
 echo ""
 $CROSSRENAME -p "$(resolve_path "$TEST_DIR")" -r --force
-echo ""
 
 # =============================================================================
-# PHASE 5: Verify results
+# PHASE 6: Rename again (custom 100-byte limit)
 # =============================================================================
-header "Phase 5: Verification"
+header "Phase 6: Rename — Custom (--max-filename-bytes 100)"
+echo -e "${YELLOW}Running: $CROSSRENAME -p $(resolve_path "$TEST_DIR") --max-filename-bytes 100 --force${NC}"
+echo ""
+$CROSSRENAME -p "$(resolve_path "$TEST_DIR")" --max-filename-bytes 100 --force
+
+# =============================================================================
+# PHASE 7: Verification
+# =============================================================================
+header "Phase 7: Verification"
 
 section "Forbidden characters removed"
-check_file_exists  "filewithbrackets.txt"       "Angle brackets removed"
-check_file_absent  "file<with>brackets.txt"      "Original with brackets gone"
-check_file_exists  "filewithcolons.txt"          "Colons removed"
-check_file_absent  "file:with:colons.txt"        "Original with colons gone"
-check_file_exists  "filewithquotes.txt"          "Quotes removed"
-check_file_absent  'file"with"quotes.txt'        "Original with quotes gone"
-check_file_exists  "filewithpipes.txt"           "Pipes removed"
-check_file_absent  "file|with|pipes.txt"         "Original with pipes gone"
-check_file_exists  "filewithquestions.txt"       "Question marks removed"
-check_file_absent  "file?with?questions.txt"     "Original with questions gone"
-check_file_exists  "filewithasterisks.txt"       "Asterisks removed"
-check_file_absent  "file*with*asterisks.txt"     "Original with asterisks gone"
-
-section "Trailing spaces and periods"
-check_file_exists  "trailing_space.txt"          "Trailing space removed"
-check_file_absent  "trailing_space .txt"         "Original with trailing space gone"
-check_file_exists  "trailing_period.txt"         "Trailing periods removed"
+check_file_exists "$TEST_DIR" "filewithbrackets.txt"    "Angle brackets removed"
+check_file_absent "$TEST_DIR" "file<with>brackets.txt"  "Original bracket file gone"
+check_file_exists "$TEST_DIR" "filewithcolons.txt"      "Colons removed"
+check_file_exists "$TEST_DIR" "filewithquestions.txt"   "Question marks removed"
+check_file_exists "$TEST_DIR" "filewithasterisks.txt"   "Asterisks removed"
+check_file_exists "$TEST_DIR" "filewithpipes.txt"       "Pipes removed"
+check_file_exists "$TEST_DIR" "filewithquotes.txt"      "Quotes removed"
 
 section "Reserved names prefixed"
-check_file_exists  "_CON.txt"                    "CON prefixed with underscore"
-check_file_absent  "CON.txt"                     "Original CON.txt gone"
-check_file_exists  "_NUL.txt"                    "NUL prefixed with underscore"
-check_file_absent  "NUL.txt"                     "Original NUL.txt gone"
-check_file_exists  "_COM1.txt"                   "COM1 prefixed with underscore"
-check_file_absent  "COM1.txt"                    "Original COM1.txt gone"
-check_file_exists  "_LPT1.txt"                   "LPT1 prefixed with underscore"
-check_file_absent  "LPT1.txt"                    "Original LPT1.txt gone"
-check_file_exists  "_PRN.txt"                    "PRN prefixed with underscore"
-check_file_absent  "PRN.txt"                     "Original PRN.txt gone"
-check_file_exists  "_AUX.txt"                    "AUX prefixed with underscore"
-check_file_absent  "AUX.txt"                     "Original AUX.txt gone"
+check_file_exists "$TEST_DIR" "_CON.txt"   "CON  → _CON"
+check_file_exists "$TEST_DIR" "_NUL.txt"   "NUL  → _NUL"
+check_file_exists "$TEST_DIR" "_COM1.txt"  "COM1 → _COM1"
+check_file_exists "$TEST_DIR" "_LPT1.txt"  "LPT1 → _LPT1"
+check_file_exists "$TEST_DIR" "_PRN.txt"   "PRN  → _PRN"
+check_file_exists "$TEST_DIR" "_AUX.txt"   "AUX  → _AUX"
 
-section "Control characters"
-check_file_exists  "filectrl.txt"                "Control char removed"
-check_file_exists  "filectrl2.txt"               "Control char removed"
+section "Control characters removed"
+check_file_exists "$TEST_DIR" "filectrl.txt"   "Control char (0x01) removed"
+check_file_exists "$TEST_DIR" "filectrl2.txt"  "Control char (0x1f) removed"
 
-section "Emoji/CJK filenames (should be unchanged)"
-check_file_exists  "🎉party🎊time.txt"           "Emoji filename preserved"
-check_file_exists  "📁folder📂icon.txt"           "Emoji filename preserved"
-check_file_exists  "日本語ファイル.txt"              "CJK filename preserved"
+section "Emoji/CJK filenames preserved"
+check_file_exists "$TEST_DIR" "🎉party🎊time.txt"   "Emoji filename preserved"
+check_file_exists "$TEST_DIR" "📁folder📂icon.txt"   "Emoji filename preserved"
+check_file_exists "$TEST_DIR" "日本語ファイル.txt"       "CJK filename preserved"
 
-section "Filename truncation"
-check_truncated  "aaaa"  255  "Long ASCII filename truncated to ≤255 bytes"
-check_truncated  "中"    255  "Long CJK filename truncated to ≤255 bytes"
-check_truncated  "😀"   255  "Long emoji filename truncated to ≤255 bytes"
-check_truncated  "bbbb"  255  "Long filename with .tar.gz truncated to ≤255 bytes"
-
-section "Combination files"
-check_file_exists  "badnamefile.txt"             "Multiple forbidden chars removed"
-check_file_absent  "bad<name>:file?.txt"         "Original combo file gone"
+section "Byte truncation (--max-filename-bytes 100)"
+check_truncated "$TEST_DIR" "中" 100 "CJK (253 bytes) truncated to ≤100 bytes"
+check_truncated "$TEST_DIR" "😀" 100 "Emoji (248 bytes) truncated to ≤100 bytes"
+check_truncated "$TEST_DIR" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" 100 "ASCII (254 bytes) truncated to ≤100 bytes"
 
 section "Clean files unchanged"
-check_file_exists  "normal_file.txt"             "Normal file unchanged"
-check_file_exists  "another-file.md"             "Normal file unchanged"
-check_file_exists  ".hidden_file"                "Hidden file unchanged"
+check_file_exists "$TEST_DIR" "normal_file.txt"  "normal_file.txt unchanged"
+check_file_exists "$TEST_DIR" "another-file.md"  "another-file.md unchanged"
+check_file_exists "$TEST_DIR" ".hidden_file"     ".hidden_file unchanged"
 
 # =============================================================================
 # Summary
 # =============================================================================
 header "Results"
-
-echo -e "  ${GREEN}Passed: $PASS${NC}"
-echo -e "  ${RED}Failed: $FAIL${NC}"
+echo -e "  ${GREEN}Passed: $PASS${NC}  ${RED}Failed: $FAIL${NC}"
 echo ""
 
-if [ -d "$TEST_DIR" ]; then
-    echo -e "${BOLD}Remaining files in test_files/:${NC}"
-    ls -1A "$TEST_DIR"
-fi
-
-echo ""
 if [ "$FAIL" -eq 0 ]; then
-    echo -e "${GREEN}${BOLD}All tests passed!${NC} 🎉"
+    echo -e "${GREEN}${BOLD}✅ All tests passed!${NC} 🎉"
     exit 0
 else
-    echo -e "${RED}${BOLD}$FAIL test(s) failed.${NC}"
+    echo -e "${RED}${BOLD}❌ $FAIL test(s) failed.${NC}"
     exit 1
 fi

--- a/tests/test_wsl.sh
+++ b/tests/test_wsl.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# =============================================================================
+# CrossRename WSL Integration Test
+# =============================================================================
+# Creates files with Windows-incompatible names on a Linux filesystem,
+# runs CrossRename against them, and verifies the results.
+#
+# Usage (from WSL):
+#   cd /mnt/c/Users/HP/Documents/Code/CrossRename
+#   bash tests/test_wsl.sh [--keep]
+#
+# From PowerShell:
+#   wsl bash -c "cd /mnt/c/Users/HP/Documents/Code/CrossRename && bash tests/test_wsl.sh"
+#
+# Options:
+#   --keep    Don't clean up test_files/ after running (for manual inspection)
+# =============================================================================
+
+set -euo pipefail
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No Color
+
+# --- Config ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_DIR="$PROJECT_DIR/test_files"
+KEEP=false
+PASS=0
+FAIL=0
+
+# --- Parse args ---
+for arg in "$@"; do
+    case "$arg" in
+        --keep) KEEP=true ;;
+        *) echo -e "${RED}Unknown argument: $arg${NC}"; exit 1 ;;
+    esac
+done
+
+# --- Helpers ---
+header() {
+    echo ""
+    echo -e "${CYAN}${BOLD}═══════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}${BOLD}  $1${NC}"
+    echo -e "${CYAN}${BOLD}═══════════════════════════════════════════════════${NC}"
+}
+
+section() {
+    echo ""
+    echo -e "${YELLOW}--- $1 ---${NC}"
+}
+
+check_file_exists() {
+    local file="$1"
+    local description="$2"
+    if [ -f "$TEST_DIR/$file" ]; then
+        echo -e "  ${GREEN}✓ PASS${NC}: $description → '$file' exists"
+        ((PASS++))
+    else
+        echo -e "  ${RED}✗ FAIL${NC}: $description → '$file' not found"
+        ((FAIL++))
+    fi
+}
+
+check_file_absent() {
+    local file="$1"
+    local description="$2"
+    if [ ! -f "$TEST_DIR/$file" ]; then
+        echo -e "  ${GREEN}✓ PASS${NC}: $description → '$file' correctly removed/renamed"
+        ((PASS++))
+    else
+        echo -e "  ${RED}✗ FAIL${NC}: $description → '$file' still exists (should have been renamed)"
+        ((FAIL++))
+    fi
+}
+
+# Verify that a file matching the prefix exists and its name is within the byte limit
+check_truncated() {
+    local prefix="$1"
+    local max_bytes="$2"
+    local description="$3"
+    local found=false
+    for f in "$TEST_DIR/$prefix"*; do
+        if [ -f "$f" ]; then
+            local basename
+            basename=$(basename "$f")
+            local byte_len
+            byte_len=$(echo -n "$basename" | wc -c)
+            if [ "$byte_len" -le "$max_bytes" ]; then
+                echo -e "  ${GREEN}✓ PASS${NC}: $description → '${basename}' (${byte_len} bytes ≤ ${max_bytes})"
+                ((PASS++))
+            else
+                echo -e "  ${RED}✗ FAIL${NC}: $description → '${basename}' is ${byte_len} bytes (limit: ${max_bytes})"
+                ((FAIL++))
+            fi
+            found=true
+            break
+        fi
+    done
+    if [ "$found" = false ]; then
+        echo -e "  ${RED}✗ FAIL${NC}: $description → no file matching '${prefix}*' found"
+        ((FAIL++))
+    fi
+}
+
+cleanup() {
+    if [ -d "$TEST_DIR" ]; then
+        rm -rf "$TEST_DIR"
+        echo -e "${YELLOW}Cleaned up $TEST_DIR${NC}"
+    fi
+}
+
+# --- Cleanup on exit (unless --keep) ---
+if [ "$KEEP" = false ]; then
+    trap cleanup EXIT
+fi
+
+# =============================================================================
+# PHASE 1: Setup
+# =============================================================================
+header "Phase 1: Setup"
+
+# Clean any previous test run
+if [ -d "$TEST_DIR" ]; then
+    echo "Removing previous test_files/..."
+    rm -rf "$TEST_DIR"
+fi
+
+mkdir -p "$TEST_DIR"
+echo -e "Created ${BOLD}$TEST_DIR${NC}"
+
+# Detect CrossRename command
+section "Detecting CrossRename"
+cd "$PROJECT_DIR"
+CROSSRENAME=""
+USE_WINPATH=false
+if command -v crossrename &>/dev/null; then
+    CROSSRENAME="crossrename"
+elif command -v crossrename.exe &>/dev/null; then
+    CROSSRENAME="crossrename.exe"
+    USE_WINPATH=true
+elif python3 -c "from CrossRename.main import main" &>/dev/null 2>&1; then
+    CROSSRENAME="python3 -m CrossRename.main"
+elif python -c "from CrossRename.main import main" &>/dev/null 2>&1; then
+    CROSSRENAME="python -m CrossRename.main"
+else
+    echo -e "${RED}ERROR: CrossRename not found.${NC}"
+    echo "  Install it with: pip install -e .  (or pip install CrossRename)"
+    exit 1
+fi
+
+# Convert paths for Windows executables running via WSL interop
+resolve_path() {
+    if [ "$USE_WINPATH" = true ]; then
+        wslpath -w "$1"
+    else
+        echo "$1"
+    fi
+}
+
+echo -e "Using: ${BOLD}$CROSSRENAME${NC}"
+$CROSSRENAME -v
+
+# =============================================================================
+# PHASE 2: Create test files
+# =============================================================================
+header "Phase 2: Creating test files"
+
+section "Forbidden Windows characters"
+touch "$TEST_DIR/file<with>brackets.txt"
+touch "$TEST_DIR/file:with:colons.txt"
+touch "$TEST_DIR/file\"with\"quotes.txt"
+touch "$TEST_DIR/file|with|pipes.txt"
+touch "$TEST_DIR/file?with?questions.txt"
+touch "$TEST_DIR/file*with*asterisks.txt"
+echo "  Created 6 files with forbidden characters"
+
+section "Trailing spaces and periods"
+touch "$TEST_DIR/trailing_space .txt"
+touch "$TEST_DIR/trailing_period..txt"
+echo "  Created 2 files with trailing spaces/periods"
+
+section "Reserved Windows names"
+touch "$TEST_DIR/CON.txt"
+touch "$TEST_DIR/NUL.txt"
+touch "$TEST_DIR/COM1.txt"
+touch "$TEST_DIR/LPT1.txt"
+touch "$TEST_DIR/PRN.txt"
+touch "$TEST_DIR/AUX.txt"
+echo "  Created 6 files with reserved names"
+
+section "Control characters"
+touch "$TEST_DIR/file$(printf '\x01')ctrl.txt"
+touch "$TEST_DIR/file$(printf '\x1f')ctrl2.txt"
+echo "  Created 2 files with control characters"
+
+section "Emoji filenames"
+touch "$TEST_DIR/🎉party🎊time.txt"
+touch "$TEST_DIR/📁folder📂icon.txt"
+touch "$TEST_DIR/日本語ファイル.txt"
+echo "  Created 3 files with emoji/CJK characters"
+
+section "Filename truncation (byte limit)"
+# 300 ASCII chars + .txt = 304 bytes (exceeds 255)
+LONG_ASCII=$(printf 'a%.0s' $(seq 1 300))
+touch "$TEST_DIR/${LONG_ASCII}.txt"
+# 100 CJK chars = 300 bytes (each is 3 bytes in UTF-8)
+LONG_CJK=$(printf '中%.0s' $(seq 1 100))
+touch "$TEST_DIR/${LONG_CJK}.txt"
+# 70 emoji = 280 bytes (each is 4 bytes in UTF-8)
+LONG_EMOJI=$(printf '😀%.0s' $(seq 1 70))
+touch "$TEST_DIR/${LONG_EMOJI}.txt"
+# Long name with compound extension
+LONG_TAR=$(printf 'b%.0s' $(seq 1 300))
+touch "$TEST_DIR/${LONG_TAR}.tar.gz"
+echo "  Created 4 files exceeding 255-byte limit"
+
+section "Combination of issues"
+touch "$TEST_DIR/bad<name>:file?.txt"
+touch "$TEST_DIR/CON:bad|name .txt"
+echo "  Created 2 files with multiple issues"
+
+section "Files that should NOT change"
+touch "$TEST_DIR/normal_file.txt"
+touch "$TEST_DIR/another-file.md"
+touch "$TEST_DIR/.hidden_file"
+echo "  Created 3 clean files (should be unchanged)"
+
+echo ""
+echo -e "${BOLD}Total files created: $(ls -1A "$TEST_DIR" | wc -l)${NC}"
+
+# =============================================================================
+# PHASE 3: Dry run
+# =============================================================================
+header "Phase 3: Dry Run"
+
+echo -e "${YELLOW}Running: $CROSSRENAME -p $(resolve_path "$TEST_DIR") -r -d${NC}"
+echo ""
+$CROSSRENAME -p "$(resolve_path "$TEST_DIR")" -r -d
+echo ""
+echo -e "${GREEN}Dry run complete. No files were renamed.${NC}"
+
+# Verify nothing actually changed in dry run
+section "Verifying dry run didn't rename anything"
+if [ -f "$TEST_DIR/file<with>brackets.txt" ]; then
+    echo -e "  ${GREEN}✓ PASS${NC}: Dry run did not modify files"
+    ((PASS++))
+else
+    echo -e "  ${RED}✗ FAIL${NC}: Dry run modified files unexpectedly"
+    ((FAIL++))
+fi
+
+# =============================================================================
+# PHASE 4: Actual rename
+# =============================================================================
+header "Phase 4: Actual Rename"
+
+echo -e "${YELLOW}Running: $CROSSRENAME -p $(resolve_path "$TEST_DIR") -r --force${NC}"
+echo ""
+$CROSSRENAME -p "$(resolve_path "$TEST_DIR")" -r --force
+echo ""
+
+# =============================================================================
+# PHASE 5: Verify results
+# =============================================================================
+header "Phase 5: Verification"
+
+section "Forbidden characters removed"
+check_file_exists  "filewithbrackets.txt"       "Angle brackets removed"
+check_file_absent  "file<with>brackets.txt"      "Original with brackets gone"
+check_file_exists  "filewithcolons.txt"          "Colons removed"
+check_file_absent  "file:with:colons.txt"        "Original with colons gone"
+check_file_exists  "filewithquotes.txt"          "Quotes removed"
+check_file_absent  'file"with"quotes.txt'        "Original with quotes gone"
+check_file_exists  "filewithpipes.txt"           "Pipes removed"
+check_file_absent  "file|with|pipes.txt"         "Original with pipes gone"
+check_file_exists  "filewithquestions.txt"       "Question marks removed"
+check_file_absent  "file?with?questions.txt"     "Original with questions gone"
+check_file_exists  "filewithasterisks.txt"       "Asterisks removed"
+check_file_absent  "file*with*asterisks.txt"     "Original with asterisks gone"
+
+section "Trailing spaces and periods"
+check_file_exists  "trailing_space.txt"          "Trailing space removed"
+check_file_absent  "trailing_space .txt"         "Original with trailing space gone"
+check_file_exists  "trailing_period.txt"         "Trailing periods removed"
+
+section "Reserved names prefixed"
+check_file_exists  "_CON.txt"                    "CON prefixed with underscore"
+check_file_absent  "CON.txt"                     "Original CON.txt gone"
+check_file_exists  "_NUL.txt"                    "NUL prefixed with underscore"
+check_file_absent  "NUL.txt"                     "Original NUL.txt gone"
+check_file_exists  "_COM1.txt"                   "COM1 prefixed with underscore"
+check_file_absent  "COM1.txt"                    "Original COM1.txt gone"
+check_file_exists  "_LPT1.txt"                   "LPT1 prefixed with underscore"
+check_file_absent  "LPT1.txt"                    "Original LPT1.txt gone"
+check_file_exists  "_PRN.txt"                    "PRN prefixed with underscore"
+check_file_absent  "PRN.txt"                     "Original PRN.txt gone"
+check_file_exists  "_AUX.txt"                    "AUX prefixed with underscore"
+check_file_absent  "AUX.txt"                     "Original AUX.txt gone"
+
+section "Control characters"
+check_file_exists  "filectrl.txt"                "Control char removed"
+check_file_exists  "filectrl2.txt"               "Control char removed"
+
+section "Emoji/CJK filenames (should be unchanged)"
+check_file_exists  "🎉party🎊time.txt"           "Emoji filename preserved"
+check_file_exists  "📁folder📂icon.txt"           "Emoji filename preserved"
+check_file_exists  "日本語ファイル.txt"              "CJK filename preserved"
+
+section "Filename truncation"
+check_truncated  "aaaa"  255  "Long ASCII filename truncated to ≤255 bytes"
+check_truncated  "中"    255  "Long CJK filename truncated to ≤255 bytes"
+check_truncated  "😀"   255  "Long emoji filename truncated to ≤255 bytes"
+check_truncated  "bbbb"  255  "Long filename with .tar.gz truncated to ≤255 bytes"
+
+section "Combination files"
+check_file_exists  "badnamefile.txt"             "Multiple forbidden chars removed"
+check_file_absent  "bad<name>:file?.txt"         "Original combo file gone"
+
+section "Clean files unchanged"
+check_file_exists  "normal_file.txt"             "Normal file unchanged"
+check_file_exists  "another-file.md"             "Normal file unchanged"
+check_file_exists  ".hidden_file"                "Hidden file unchanged"
+
+# =============================================================================
+# Summary
+# =============================================================================
+header "Results"
+
+echo -e "  ${GREEN}Passed: $PASS${NC}"
+echo -e "  ${RED}Failed: $FAIL${NC}"
+echo ""
+
+if [ -d "$TEST_DIR" ]; then
+    echo -e "${BOLD}Remaining files in test_files/:${NC}"
+    ls -1A "$TEST_DIR"
+fi
+
+echo ""
+if [ "$FAIL" -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}All tests passed!${NC} 🎉"
+    exit 0
+else
+    echo -e "${RED}${BOLD}$FAIL test(s) failed.${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Fixes #8 

Replace character-based truncation with byte-aware logic to match ext4/btrfs 255-byte filesystem limit. Multi-byte UTF-8 characters (CJK, Cyrillic, emoji) are now correctly accounted for during truncation.

Add --max-filename-bytes N flag (range: 4–255, default: 255) to allow custom byte limits. Propagate max_bytes through sanitize_filename, rename_file, and rename_directory.

Add tests/test_sanitize.py covering byte-limit truncation and character sanitization. Add tests/test_wsl.sh for WSL integration testing against a real Linux filesystem.