### PR TITLE
feat: add -q/--quiet flag to suppress informational messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extracted core rename logic (`get_extension`, `sanitize_filename`, `rename_file`, `rename_directory`, `file_search`, `collect_directories`) from `main.py` into new `rename.py` module; `main.py` now handles only CLI concerns
 - Updated `check_for_update()` up-to-date message to point users to the feedback form instead of `--credits`
 - Added feedback form link to `README.md` and `PYPI_README.rst` usage sections
+- Minimum `--max-filename-bytes` raised from 4 to 16 (the previous floor of 4 was arbitrary and could produce degenerate extension-only filenames)
 
 ### Added
 
@@ -46,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `-q`/`--quiet` flag to suppress "No change needed" and other informational messages
   (e.g., symlink skips) in recursive mode, so only files/directories that are actually
   renamed appear in output ([#10](https://github.com/Jemeni11/CrossRename/issues/10))
+- `Makefile` with targets for `test`, `lint`, `format`, `typecheck`, `check`, `all`, and `clean`
+- Quiet mode test suite (`TestQuietMode`) — 9 tests covering file and directory renaming with
+  `-q`/`--quiet`, dry-run + quiet, and log suppression; existing tests converted to `unittest.TestCase`
+
+### Fixed
+
+- Truncation now explicitly returns extension-only when the extension alone exceeds `--max-filename-bytes`, rather than relying on an accidental loop guard.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `.python-version` file pinning development to Python 3.14
 - `py.typed` marker file for PEP 561 type information support
 - Dev dependency groups (`ruff`, `ty`) with comprehensive ruff lint rule selection
+- `-q`/`--quiet` flag to suppress "No change needed" and other informational messages
+  (e.g., symlink skips) in recursive mode, so only files/directories that are actually
+  renamed appear in output ([#10](https://github.com/Jemeni11/CrossRename/issues/10))
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ format-check:
 # ── Type Check ────────────────────────────────────────────────────────
 
 typecheck:
-	uv run ty src/
+	uv run ty check src/
 
 # ── Combined ──────────────────────────────────────────────────────────
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+# CrossRename development tasks
+# All commands use `uv run`
+
+.PHONY: help test lint format typecheck check clean
+
+# Default target
+help:
+	@echo "CrossRename dev tasks:"
+	@echo ""
+	@echo "  make test       Run the test suite"
+	@echo "  make lint       Lint with ruff"
+	@echo "  make format     Format code with ruff"
+	@echo "  make typecheck  Type-check with ty"
+	@echo "  make check      Run lint + typecheck (CI pipeline)"
+	@echo "  make all        Run format + lint + typecheck + test"
+	@echo "  make clean      Remove build artifacts and caches"
+
+# ── Test ─────────────────────────────────────────────────────────────
+
+test:
+	PYTHONPATH=src uv run python -m unittest tests.test_sanitize -v
+
+# ── Lint & Format ─────────────────────────────────────────────────────
+
+lint:
+	uv run ruff check src/ tests/
+
+format:
+	uv run ruff format src/ tests/
+
+format-check:
+	uv run ruff format --check src/ tests/
+
+# ── Type Check ────────────────────────────────────────────────────────
+
+typecheck:
+	uv run ty src/
+
+# ── Combined ──────────────────────────────────────────────────────────
+
+check: lint typecheck
+	@echo "✓ Lint and type checks passed"
+
+all: format lint typecheck test
+	@echo "✓ All checks and tests passed"
+
+# ── Cleanup ───────────────────────────────────────────────────────────
+
+clean:
+	@echo "Cleaning build artifacts..."
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg-info/
+	rm -rf src/*.egg-info/
+	rm -rf .pytest_cache/
+	rm -rf .ruff_cache/
+	rm -rf __pycache__/
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	@echo "✓ Clean"

--- a/PYPI_README.rst
+++ b/PYPI_README.rst
@@ -73,9 +73,9 @@ Usage
 
 .. code-block:: text
 
-   usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--max-filename-bytes N] [--credits]
+   usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [-q] [--credits] [--max-filename-bytes N]
 
-   CrossRename: Harmonize file and directory names for Linux, Windows and macOS.
+   Harmonize file and directory names for Linux, Windows and macOS.
 
    options:
      -h, --help                  show this help message and exit
@@ -87,8 +87,9 @@ Usage
      -D, --rename-directories    Also rename directories to be cross-platform compatible. Use with caution!
      -a, --use-alternatives      Replace forbidden characters with Unicode lookalikes instead of removing them. May cause display issues on some systems.
      --force                     Skip safety prompts (useful for automated scripts)
-     --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 4-255).
+     -q, --quiet                 Suppress 'No change needed' and other informational messages. Only shows files that are actually renamed, plus warnings and errors.
      --credits                   Show credits and support information
+     --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 16-255). Filenames exceeding this limit will be truncated. The default of 255 bytes ensures compatibility with Linux filesystems (ext4, btrfs). Multi-byte characters (CJK, Cyrillic, emoji) consume more bytes per character.
 
    Made with <3 by Emmanuel Jemeni | Send Feedback: https://tally.so/r/7Rjpgz?project=CrossRename
 
@@ -156,6 +157,13 @@ Limit filename length for Linux filesystems (useful for CJK or emoji-heavy filen
 .. code-block:: bash
 
    crossrename -p /path/to/directory -r --max-filename-bytes 255
+
+Suppress informational messages to see only files that will be renamed:
+
+.. code-block:: bash
+
+   crossrename -p /path/to/directory -r -d -q
+   # Only shows [Dry-run] Would rename: ... lines and skips "No change needed" noise
 
 `back to introduction  <introduction_>`__
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Other package managers coming soon.
 ## Usage
 
 ```bash
-usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [--max-filename-bytes N] [--credits]
+usage: crossrename [-h] [-p PATH] [-v] [-u] [-r] [-d] [-D] [-a] [--force] [-q] [--credits] [--max-filename-bytes N]
 
-CrossRename: Harmonize file and directory names for Linux, Windows and macOS.
+Harmonize file and directory names for Linux, Windows and macOS.
 
 options:
   -h, --help                  show this help message and exit
@@ -84,8 +84,9 @@ options:
   -D, --rename-directories    Also rename directories to be cross-platform compatible. Use with caution!
   -a, --use-alternatives      Replace forbidden characters with Unicode lookalikes instead of removing them. May cause display issues on some systems.
   --force                     Skip safety prompts (useful for automated scripts)
-  --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 4-255).
+  -q, --quiet                 Suppress 'No change needed' and other informational messages. Only shows files that are actually renamed, plus warnings and errors.
   --credits                   Show credits and support information
+  --max-filename-bytes N      Maximum filename length in bytes (default: 255, valid range: 16-255). Filenames exceeding this limit will be truncated. The default of 255 bytes ensures compatibility with Linux filesystems (ext4, btrfs). Multi-byte characters (CJK, Cyrillic, emoji) consume more bytes per character.
 
 Made with <3 by Emmanuel Jemeni | Send Feedback: https://tally.so/r/7Rjpgz?project=CrossRename
 ```
@@ -154,6 +155,13 @@ Limit filename length for Linux filesystems (useful for CJK or emoji-heavy filen
 crossrename -p /path/to/directory -r --max-filename-bytes 255
 ```
 
+Suppress informational messages to see only files that will be renamed:
+
+```bash
+crossrename -p /path/to/directory -r -d -q
+# Only shows [Dry-run] Would rename: ... lines and skips "No change needed" noise
+```
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ### Unicode Alternatives Mode
@@ -180,7 +188,6 @@ Character mappings:
 > [!WARNING]
 >
 > These Unicode characters may not display correctly on all systems, fonts, or applications.
-
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/src/crossrename/main.py
+++ b/src/crossrename/main.py
@@ -128,6 +128,13 @@ def main() -> None:
             action="store_true",
         )
         parser.add_argument(
+            "-q",
+            "--quiet",
+            help="Suppress 'No change needed' and other informational messages. "
+            "Only shows files that are actually renamed, plus warnings and errors.",
+            action="store_true",
+        )
+        parser.add_argument(
             "--credits",
             help="Show credits and support information",
             action="store_true",
@@ -150,6 +157,7 @@ def main() -> None:
         rename_dirs = args.rename_directories
         use_alternatives = args.use_alternatives
         max_bytes = args.max_filename_bytes
+        quiet = args.quiet
 
         if not (4 <= max_bytes <= 255):
             sys.exit("Error: --max-filename-bytes must be between 4 and 255.")
@@ -174,27 +182,27 @@ def main() -> None:
             )
 
         if Path(path).is_file():
-            rename_file(Path(path), dry_run, use_alternatives, max_bytes)
+            rename_file(Path(path), dry_run, use_alternatives, max_bytes, quiet)
         elif Path(path).is_dir():
             if recursive:
                 # First rename directories (deepest first)
                 if rename_dirs:
                     directories: list[Path] = collect_directories(path)
                     for dir_path in directories:
-                        rename_directory(dir_path, dry_run, use_alternatives, max_bytes)
+                        rename_directory(dir_path, dry_run, use_alternatives, max_bytes, quiet)
 
                 # Then rename files (using updated paths)
-                file_list: list[Path] = file_search(path)
+                file_list: list[Path] = file_search(path, quiet)
                 for file_path in file_list:
-                    rename_file(file_path, dry_run, use_alternatives, max_bytes)
+                    rename_file(file_path, dry_run, use_alternatives, max_bytes, quiet)
             else:
                 if rename_dirs:
-                    path = rename_directory(Path(path), dry_run, use_alternatives, max_bytes)
+                    path = rename_directory(Path(path), dry_run, use_alternatives, max_bytes, quiet)
 
                 # Handle files in the directory
                 for item in Path(path).iterdir():
                     if item.is_file():
-                        rename_file(item, dry_run, use_alternatives, max_bytes)
+                        rename_file(item, dry_run, use_alternatives, max_bytes, quiet)
         else:
             sys.exit(f"Error: {path} is not a valid file or directory")
     except Exception as e:

--- a/src/crossrename/main.py
+++ b/src/crossrename/main.py
@@ -144,7 +144,7 @@ def main() -> None:
             type=int,
             default=255,
             metavar="N",
-            help="Maximum filename length in bytes (default: 255, valid range: 4-255). "
+            help="Maximum filename length in bytes (default: 255, valid range: 16-255). "
             "Filenames exceeding this limit will be truncated. The default of 255 bytes "
             "ensures compatibility with Linux filesystems (ext4, btrfs). "
             "Multi-byte characters (CJK, Cyrillic, emoji) consume more bytes per character.",
@@ -159,8 +159,8 @@ def main() -> None:
         max_bytes = args.max_filename_bytes
         quiet = args.quiet
 
-        if not (4 <= max_bytes <= 255):
-            sys.exit("Error: --max-filename-bytes must be between 4 and 255.")
+        if not (16 <= max_bytes <= 255):
+            sys.exit("Error: --max-filename-bytes must be between 16 and 255.")
 
         if args.update:
             check_for_update(__version__)

--- a/src/crossrename/rename.py
+++ b/src/crossrename/rename.py
@@ -79,6 +79,13 @@ def sanitize_filename(filename: str, use_alternatives: bool = False, max_bytes: 
     if len(sanitized.encode("utf-8")) > max_bytes:
         ext = get_extension(sanitized)
         ext_bytes = len(ext.encode("utf-8"))
+
+        # Extension alone exceeds the byte limit, then the stem is unsalvageable.
+        # Return extension as-is; the limit is best-effort when the extension
+        # itself is too large to fit.
+        if ext_bytes >= max_bytes:
+            return ext
+
         name = sanitized[: -len(ext)] if ext else sanitized
         # Remove characters from the end until the total fits within the byte limit
         while len(name.encode("utf-8")) + ext_bytes > max_bytes and name:

--- a/src/crossrename/rename.py
+++ b/src/crossrename/rename.py
@@ -89,7 +89,11 @@ def sanitize_filename(filename: str, use_alternatives: bool = False, max_bytes: 
 
 
 def rename_file(
-    file_path: Path, dry_run: bool = False, use_alternatives: bool = False, max_bytes: int = 255
+    file_path: Path,
+    dry_run: bool = False,
+    use_alternatives: bool = False,
+    max_bytes: int = 255,
+    quiet: bool = False,
 ) -> None:
     directory, filename = file_path.parent, file_path.name
     new_filename = sanitize_filename(filename, use_alternatives, max_bytes)
@@ -127,11 +131,11 @@ def rename_file(
                 logger.error(f"Target file already exists (race condition): {new_filename}")
             except Exception as e:
                 logger.error(f"Error renaming {filename}: {str(e)}")
-    else:
+    elif not quiet:
         logger.info(f"No change needed: {filename}")
 
 
-def file_search(directory: str) -> list[Path]:
+def file_search(directory: str, quiet: bool = False) -> list[Path]:
     file_list: list[Path] = []
     visited_paths: set[Path] = set()
 
@@ -147,7 +151,8 @@ def file_search(directory: str) -> list[Path]:
         for file in files:
             file_path = root / file
             if file_path.is_symlink():
-                logger.info(f"Skipping symlink: {file_path}")
+                if not quiet:
+                    logger.info(f"Skipping symlink: {file_path}")
                 continue
             file_list.append(file_path)
 
@@ -168,7 +173,11 @@ def collect_directories(directory: str) -> list[Path]:
 
 
 def rename_directory(
-    dir_path: Path, dry_run: bool = False, use_alternatives: bool = False, max_bytes: int = 255
+    dir_path: Path,
+    dry_run: bool = False,
+    use_alternatives: bool = False,
+    max_bytes: int = 255,
+    quiet: bool = False,
 ) -> Path:
     """Rename directory and return the new path"""
     parent_dir, dir_name = dir_path.parent, dir_path.name
@@ -187,5 +196,6 @@ def rename_directory(
             logger.error(f"Error renaming directory {dir_name}: {str(e)}")
             return dir_path  # Return original path if rename failed
     else:
-        logger.info(f"No change needed for directory: {dir_name}")
+        if not quiet:
+            logger.info(f"No change needed for directory: {dir_name}")
         return dir_path

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,135 +1,311 @@
-from crossrename.rename import get_extension, sanitize_filename
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from crossrename.rename import (
+    get_extension,
+    rename_directory,
+    rename_file,
+    sanitize_filename,
+)
 
 
-class TestGetExtension:
+class TestGetExtension(unittest.TestCase):
     def test_simple_extension(self):
-        assert get_extension("file.txt") == ".txt"
+        self.assertEqual(get_extension("file.txt"), ".txt")
 
     def test_compound_extension(self):
-        assert get_extension("archive.tar.gz") == ".tar.gz"
+        self.assertEqual(get_extension("archive.tar.gz"), ".tar.gz")
 
     def test_no_extension(self):
-        assert get_extension("README") == ""
+        self.assertEqual(get_extension("README"), "")
 
     def test_dotfile(self):
         # Path('.gitignore').suffixes returns [] — Python treats it as a stem, not an extension
-        assert get_extension(".gitignore") == ""
+        self.assertEqual(get_extension(".gitignore"), "")
 
 
-class TestSanitizeFilenameByteLimit:
+class TestSanitizeFilenameByteLimit(unittest.TestCase):
     """Tests for byte-aware filename truncation (issue #8)."""
 
     def test_ascii_at_255_bytes_unchanged(self):
         """255 ASCII chars = 255 bytes, should not be truncated."""
         name = "a" * 251 + ".txt"  # 251 + 4 = 255 bytes
         result = sanitize_filename(name)
-        assert result == name
-        assert len(result.encode("utf-8")) == 255
+        self.assertEqual(result, name)
+        self.assertEqual(len(result.encode("utf-8")), 255)
 
     def test_ascii_exceeding_255_bytes_truncated(self):
         """256+ ASCII chars should be truncated to fit 255 bytes."""
         name = "a" * 260 + ".txt"
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        assert result.endswith(".txt")
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
+        self.assertTrue(result.endswith(".txt"))
 
     def test_cjk_exceeding_255_bytes(self):
         """CJK chars are 3 bytes each in UTF-8. 100 CJK chars = 300 bytes."""
         name = "中" * 100  # 300 bytes
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        # Should be ~85 characters (85 * 3 = 255)
-        assert len(result) == 85
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
 
     def test_cjk_with_extension(self):
         """CJK filename with extension: extension must be preserved."""
         name = "中" * 100 + ".txt"  # 300 + 4 = 304 bytes
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        assert result.endswith(".txt")
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
+        self.assertTrue(result.endswith(".txt"))
 
     def test_emoji_exceeding_255_bytes(self):
         """Emoji are 4 bytes each in UTF-8. 70 emoji = 280 bytes."""
         name = "😀" * 70
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        # Should be ~63 characters (63 * 4 = 252)
-        assert len(result) == 63
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
 
     def test_cyrillic_exceeding_255_bytes(self):
         """Cyrillic chars are 2 bytes each. 200 Cyrillic chars = 400 bytes."""
         name = "щ" * 200
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        # Should be ~127 characters (127 * 2 = 254)
-        assert len(result) == 127
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
 
     def test_mixed_ascii_and_multibyte(self):
         """Mixed ASCII + CJK should be byte-counted correctly."""
         # 100 ASCII (100 bytes) + 60 CJK (180 bytes) = 280 bytes
         name = "a" * 100 + "中" * 60
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
 
     def test_exactly_255_bytes_unchanged(self):
         """A filename at exactly 255 bytes should not be modified."""
         name = "中" * 85  # 85 * 3 = 255 bytes
         result = sanitize_filename(name)
-        assert result == name
-        assert len(result.encode("utf-8")) == 255
+        self.assertEqual(result, name)
+        self.assertEqual(len(result.encode("utf-8")), 255)
 
     def test_compound_extension_preserved(self):
         """Compound extensions like .tar.gz should be preserved during truncation."""
         name = "中" * 100 + ".tar.gz"  # 300 + 7 = 307 bytes
         result = sanitize_filename(name)
-        assert len(result.encode("utf-8")) <= 255
-        assert result.endswith(".tar.gz")
+        self.assertLessEqual(len(result.encode("utf-8")), 255)
+        self.assertTrue(result.endswith(".tar.gz"))
 
     def test_custom_max_bytes_lower(self):
         """Custom max_bytes should truncate accordingly."""
         name = "a" * 200
         result = sanitize_filename(name, max_bytes=100)
-        assert len(result.encode("utf-8")) <= 100
-        assert len(result) == 100
+        self.assertLessEqual(len(result.encode("utf-8")), 100)
 
     def test_custom_max_bytes_with_extension(self):
         """Custom max_bytes with extension preserved."""
         name = "a" * 200 + ".py"
         result = sanitize_filename(name, max_bytes=50)
-        assert len(result.encode("utf-8")) <= 50
-        assert result.endswith(".py")
+        self.assertLessEqual(len(result.encode("utf-8")), 50)
+        self.assertTrue(result.endswith(".py"))
 
     def test_short_filename_unchanged(self):
         """Short filenames should never be truncated."""
         name = "hello.txt"
         result = sanitize_filename(name)
-        assert result == name
+        self.assertEqual(result, name)
+
+    def test_extension_longer_than_max_bytes(self):
+        """Extension longer than max_bytes: stem is dropped, extension preserved.
+
+        The CLI enforces max_bytes >= 16, so this path is unreachable via the
+        command line.  We test it via direct function call to verify the
+        best-effort contract: when the extension alone exceeds the limit, the
+        stem is dropped and the extension returned as-is.
+        """
+        # .tar.gz is 7 bytes; max_bytes=6 means the ext alone exceeds the limit.
+        name = "a.tar.gz"
+        result = sanitize_filename(name, max_bytes=6)
+        self.assertEqual(result, ".tar.gz")
 
 
-class TestSanitizeFilenameCharacters:
+class TestSanitizeFilenameCharacters(unittest.TestCase):
     """Tests for character sanitization (existing behavior)."""
 
     def test_removes_windows_forbidden_chars(self):
         result = sanitize_filename('file<name>with:bad"chars.txt')
-        assert result == "filenamewithbadchars.txt"
+        self.assertEqual(result, "filenamewithbadchars.txt")
 
     def test_unicode_alternatives_mode(self):
         result = sanitize_filename("file<name>.txt", use_alternatives=True)
-        assert "ᐸ" in result
-        assert "ᐳ" in result
+        self.assertIn("ᐸ", result)
+        self.assertIn("ᐳ", result)
 
     def test_reserved_names_prefixed(self):
         result = sanitize_filename("CON.txt")
-        assert result == "_CON.txt"
+        self.assertEqual(result, "_CON.txt")
 
     def test_trailing_spaces_and_periods_removed(self):
         result = sanitize_filename("file.txt...")
-        assert result == "file.txt"
+        self.assertEqual(result, "file.txt")
 
     def test_empty_after_sanitization(self):
         result = sanitize_filename('<<<>>>"')
-        assert result == "unnamed_file"
+        self.assertEqual(result, "unnamed_file")
 
     def test_control_characters_removed(self):
         result = sanitize_filename("file\x01\x02name.txt")
-        assert result == "filename.txt"
+        self.assertEqual(result, "filename.txt")
+
+
+class TestQuietMode(unittest.TestCase):
+    """Tests for the -q/--quiet flag behavior.
+
+    On Windows, we cannot create files with forbidden characters (<, >, :, etc.)
+    directly on disk, so tests that need a simulated rename use
+    unittest.mock.patch on sanitize_filename.
+    """
+
+    LOGGER_NAME = "crossrename.rename"
+
+    # ── rename_file: suppression ──────────────────────────────────────
+
+    def test_rename_file_quiet_suppresses_no_change_message(self):
+        """With quiet=True, a clean file emits NO info-level log output at all."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "clean_file.txt"
+            file_path.write_text("test content")
+
+            # When quiet=True and the file needs no rename, zero INFO logs
+            # are emitted, so assertLogs should raise AssertionError.
+            with (
+                self.assertRaises(
+                    AssertionError, msg="Expected no INFO logs in quiet mode for a clean file"
+                ),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO"),
+            ):
+                rename_file(file_path, quiet=True)
+
+    def test_rename_file_default_logs_no_change_message(self):
+        """With quiet=False (default), 'No change needed' is logged for a clean file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "clean_file.txt"
+            file_path.write_text("test content")
+
+            with self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm:
+                rename_file(file_path)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("No change needed", log_text)
+            self.assertIn("clean_file.txt", log_text)
+
+    # ── rename_file: actual renames still logged ──────────────────────
+
+    def test_rename_file_quiet_still_logs_actual_rename(self):
+        """With quiet=True, actual rename messages are still emitted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "keep_me.txt"
+            file_path.write_text("test content")
+
+            # Mock sanitize_filename to simulate a rename. The real
+            # filename is clean (cross-platform safe); the mock makes
+            # rename_file think a rename is needed.
+            with (
+                patch("crossrename.rename.sanitize_filename", return_value="renamed_file.txt"),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm,
+            ):
+                rename_file(file_path, quiet=True)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("Renamed:", log_text)
+            self.assertNotIn("No change needed", log_text)
+
+    def test_rename_file_quiet_dry_run_still_logs_preview(self):
+        """Dry-run + quiet still shows rename previews for changed files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "keep_me.txt"
+            file_path.write_text("test content")
+
+            with (
+                patch("crossrename.rename.sanitize_filename", return_value="renamed_file.txt"),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm,
+            ):
+                rename_file(file_path, dry_run=True, quiet=True)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("[Dry-run] Would rename:", log_text)
+            self.assertNotIn("No change needed", log_text)
+
+    # ── rename_directory: suppression ─────────────────────────────────
+
+    def test_rename_directory_quiet_suppresses_no_change_message(self):
+        """With quiet=True, a clean directory emits NO info-level log output."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = Path(tmpdir) / "clean_dir"
+            dir_path.mkdir()
+
+            with (
+                self.assertRaises(
+                    AssertionError, msg="Expected no INFO logs in quiet mode for a clean dir"
+                ),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO"),
+            ):
+                rename_directory(dir_path, quiet=True)
+
+    def test_rename_directory_default_logs_no_change_message(self):
+        """With quiet=False (default), 'No change needed for directory' IS logged."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = Path(tmpdir) / "clean_dir"
+            dir_path.mkdir()
+
+            with self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm:
+                rename_directory(dir_path)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("No change needed for directory", log_text)
+            self.assertIn("clean_dir", log_text)
+
+    # ── rename_directory: actual renames still logged ─────────────────
+
+    def test_rename_directory_quiet_still_logs_actual_rename(self):
+        """With quiet=True, actual directory rename messages are still emitted."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dir_path = Path(tmpdir) / "keep_me"
+            dir_path.mkdir()
+
+            with (
+                patch("crossrename.rename.sanitize_filename", return_value="renamed_dir"),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm,
+            ):
+                rename_directory(dir_path, quiet=True)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("Renamed directory:", log_text)
+            self.assertNotIn("No change needed for directory", log_text)
+
+    # ── integration: mixed quiet + dry-run ────────────────────────────
+
+    def test_dry_run_mixed_quiet_only_shows_changes(self):
+        """Dry-run + quiet: rename previews appear, 'No change needed' does not."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Both files actually exist on disk so the test doesn't rely on
+            # dry-run coincidentally skipping existence checks.
+            dirty_file = Path(tmpdir) / "needs_rename.txt"
+            dirty_file.write_text("test")
+            clean_file = Path(tmpdir) / "clean.txt"
+            clean_file.write_text("test")
+
+            # Mock: the "needs_rename" file gets a different sanitized name;
+            # the clean file gets its own name back (no change).
+            with (
+                patch(
+                    "crossrename.rename.sanitize_filename",
+                    side_effect=lambda name, *a, **kw: (
+                        "renamed.txt" if name == "needs_rename.txt" else name
+                    ),
+                ),
+                self.assertLogs(logger=self.LOGGER_NAME, level="INFO") as cm,
+            ):
+                rename_file(dirty_file, dry_run=True, quiet=True)
+                rename_file(clean_file, dry_run=True, quiet=True)
+
+            log_text = "\n".join(cm.output)
+            self.assertIn("[Dry-run] Would rename:", log_text)
+            self.assertNotIn("No change needed", log_text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduce a --quiet flag that suppresses "No change needed" messages and symlink skip notices in recursive mode, so only files/directories that are actually renamed appear in the output.

- Add -q/--quiet argument to CLI parser
- Propagate quiet parameter through rename_file(), file_search(), and rename_directory()
- Conditionally suppress non-error log messages
- Update CHANGELOG

Closes #10 